### PR TITLE
Remove x64 requirement

### DIFF
--- a/Source/RmlUi/RmlUi.Build.cs
+++ b/Source/RmlUi/RmlUi.Build.cs
@@ -60,7 +60,5 @@ public class RmlUi : GameModule
         // TODO: Check support in other platforms
         if (options.Platform.Target != TargetPlatform.Windows)
             throw new InvalidPlatformException(options.Platform.Target);
-        if (options.Architecture != TargetArchitecture.x64)
-            throw new InvalidArchitectureException(options.Architecture);
     }
 }


### PR DESCRIPTION
Currently, if you would try generating a solution with this plugin as a dependency, it would fail due to a missing x32 support. Removing this line fixes this. Considering the fact that Flax is going to remove x32 support completely, this line would be obsolete anyway.