### PR TITLE
Remove `freetype` usage to support packaged engine

### DIFF
--- a/Source/RmlUi/Flax/FlaxFontEngineInterface.cpp
+++ b/Source/RmlUi/Flax/FlaxFontEngineInterface.cpp
@@ -18,7 +18,6 @@
 #include <Engine/Render2D/FontAsset.h>
 #include <Engine/Render2D/FontManager.h>
 #include <Engine/Render2D/FontTextureAtlas.h>
-#include <Engine/Render2D/IncludeFreeType.h>
 #include <Engine/Profiler/ProfilerCPU.h>
 
 // FontManager scales the face size by DPI
@@ -123,10 +122,8 @@ bool FlaxFontEngineInterface::LoadFontFace(const Rml::String& file_name, bool fa
     if (fontAsset == nullptr)
         return false;
 
-    long fontStyleFlags = fontAsset->GetFTFace()->style_flags;
-
-    bool isItalic = (fontStyleFlags & FT_STYLE_FLAG_ITALIC) != 0;
-    bool isBold = (fontStyleFlags & FT_STYLE_FLAG_BOLD) != 0;
+    bool isItalic = EnumHasAllFlags(fontAsset->GetOptions().Flags, FontFlags::Italic);
+    bool isBold = EnumHasAllFlags(fontAsset->GetOptions().Flags, FontFlags::Bold);
     if (weight == Rml::Style::FontWeight::Auto)
     {
         if (isBold)

--- a/Source/RmlUi/RmlUi.Build.cs
+++ b/Source/RmlUi/RmlUi.Build.cs
@@ -38,7 +38,6 @@ public class RmlUi : GameModule
 
 		options.PublicDependencies.Add("Core");
 		options.PublicDependencies.Add("Graphics");
-        options.PrivateDependencies.Add("freetype");
 
         if (options.Target.IsEditor)
         {


### PR DESCRIPTION
`Engine/Render2D/IncludeFreeType.h` and `freetype.lib` are not bunded with packaged Flax Editor but this plugin doesn't need to access them because we can just use Font Asset flags to check for bold/italic font style.