### PR TITLE
Allow automatic re-importing of .rml and .rcss files by clearing caches on import.

### DIFF
--- a/Source/RmlUi/RmlUiImport.cpp
+++ b/Source/RmlUi/RmlUiImport.cpp
@@ -9,6 +9,7 @@
 #include <Engine/Scripting/ManagedCLR/MClass.h>
 #include <Engine/Scripting/ManagedCLR/MMethod.h>
 #include <Engine/Scripting/Scripting.h>
+#include <Core/Factory.h>
 
 CreateAssetResult ImportRmlUiAsset(CreateAssetContext& context)
 {
@@ -23,6 +24,8 @@ CreateAssetResult ImportRmlUiAsset(CreateAssetContext& context)
     auto chunk = context.Data.Header.Chunks[0];
     chunk->Data.Allocate(inputData.Length() * sizeof(char));
     Platform::MemoryCopy(chunk->Get(), inputData.Get(), chunk->Data.Length());
+
+    Rml::Factory::ClearStyleSheetCache();
 
     return CreateAssetResult::Ok;
 }
@@ -40,6 +43,8 @@ CreateAssetResult ImportRmlUiDocumentAsset(CreateAssetContext& context)
     auto chunk = context.Data.Header.Chunks[0];
     chunk->Data.Allocate(inputData.Length() * sizeof(char));
     Platform::MemoryCopy(chunk->Get(), inputData.Get(), chunk->Data.Length());
+
+    Rml::Factory::ClearTemplateCache();
 
     return CreateAssetResult::Ok;
 }


### PR DESCRIPTION
This PR will allow automatic importing by clearing style cache when you import a .rcss file, and clearing the template cache when you import a .rml file.
I'm not sure if this change should be accepted as a general thing, but I think clearing the cache when you import an asset is likely important, but maybe it would scale poorly.