### PR TITLE
Expose GetContext() from RmlUiDocument.

### DIFF
--- a/Source/RmlUi/RmlUiDocument.h
+++ b/Source/RmlUi/RmlUiDocument.h
@@ -54,6 +54,11 @@ public:
     Rml::ElementDocument* GetDocument() const;
 
     /// <summary>
+    /// Returns the Rml::Context of the wrapped Rml:ElementDocument.
+    /// </summary>
+    Rml::Context* GetContext() const;
+
+    /// <summary>
     /// Loads the wrapped document asset.
     /// </summary>
     /// <returns>Returns true if the document was loaded successfully.</returns>
@@ -96,7 +101,6 @@ public:
 
 private:
     RmlUiCanvas* GetCanvas() const;
-    Rml::Context* GetContext() const;
 
 protected:
     // [Actor]


### PR DESCRIPTION
This PR exposes `RmlUiDocument::GetContext()` so that you can access the context and create data bindings before you load or show the actual document that was wrapped.